### PR TITLE
Fix thinko in TypePrecision

### DIFF
--- a/ltx/types.tex
+++ b/ltx/types.tex
@@ -139,6 +139,7 @@ The bit precision of a funamental type is a value of type \type{TypePrecision} d
 		Default,
 		Short,
 		Long,
+		Bit8,
 		Bit16,
 		Bit32,
 		Bit64,
@@ -151,6 +152,7 @@ with the following meaning:
   \item \code{TypePrecision::Default}: the default precision of the basis type
   \item \code{TypePrecision::Short}: the \code{short} variant of the basis type
   \item \code{TypePrecision::Long}: the \code{long} variant of the basis type
+  \item \code{TypePrecision::Bit8}: the 8-bit variant of the basis type
   \item \code{TypePrecision::Bit16}: the 16-bit variant of the basis type
   \item \code{TypePrecision::Bit32}: the 32-bit variant of the basis type
   \item \code{TypePrecision::Bit64}: the 64-bit variant of the basis type


### PR DESCRIPTION
The `Bit8` value was forgotten.

Fix #9