### PR TITLE
feat: update releases when release branches change

### DIFF
--- a/.github/workflows/produce-branch-pdf.yml
+++ b/.github/workflows/produce-branch-pdf.yml
@@ -1,0 +1,30 @@
+# Creates or updates a release's generated PDF when a change occurs
+# to a release branch
+name: Update Existing Release
+on:
+  push:
+    branches:
+      - "release/*"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "RELEASE_NAME=$(echo ${GITHUB_REF#refs/heads/release/})" >> $GITHUB_ENV
+      - name: Compile document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: ifc.tex
+          working_directory: ltx
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: ${{env.RELEASE_NAME}}
+          prerelease: false
+          title: ${{env.RELEASE_NAME}}
+          files: ltx/ifc.pdf

--- a/.github/workflows/produce-prerelease.yaml
+++ b/.github/workflows/produce-prerelease.yaml
@@ -1,4 +1,5 @@
-
+# Creates or updates a 'prerelease' release whenever main is
+# changed. Attaches a built PDF to that release.
 name: Create prerelease PDF
 on:
   push:
@@ -17,11 +18,12 @@ jobs:
           root_file: ifc.tex
           working_directory: ltx
 
-      - name: Create Release
-        uses: ncipollo/release-action@v1.8.10
+      - name: Create prerelease
+        uses: "marvinpinto/action-automatic-releases@latest"
         with:
-          allowUpdates: true
-          name: prerelease
-          tag: prerelease
-          artifacts: ltx/ifc.pdf
-          removeArtifacts: true
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "prerelease"
+          prerelease: true
+          title: "Prerelease"
+          files: |
+            ltx/ifc.pdf

--- a/.github/workflows/produce-release-branch.yml
+++ b/.github/workflows/produce-release-branch.yml
@@ -1,0 +1,17 @@
+# Creates a release branch whenever a release is created.
+
+name: Create Release Branch
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  create_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: 'release/${{ github.event.release.tag_name }}'

--- a/.github/workflows/produce-release-pdf.yml
+++ b/.github/workflows/produce-release-pdf.yml
@@ -1,8 +1,11 @@
-name: Build PDF document
+# Builds a PDF of the IFC spec and attaches it to any release that
+# is created.
+
+name: Attach PDF to Release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build_latex:


### PR DESCRIPTION
This change enables automatic PDF generation for releases when release
branches are changed. This supports backporting changes to prior
releases.

This works by:
  - Creating a branch named `release/XYZ`, where XYZ is the name of a
    release, when a release is made.
  - Activating PDF generation when `release/XYZ` branches are changed.
  - Updating the release XYZ when PDF generation is finished.

The release may be named anything. The only portion of the name that is
important for these actions is `release/` in the branch name.

The generated PDFs will be accessible from the Release pages and the links
to these PDFs are stable.

No manual work needs to be done beyond creating a release. All other steps
should happen automatically as normal development happens.