### PR TITLE
Temporarily make operator semantic resolution an expression

### DIFF
--- a/ltx/exprs.tex
+++ b/ltx/exprs.tex
@@ -502,7 +502,7 @@ Each entry in that partition is a structure with the following layout
 	\structure{
 		\DeclareMember{locus}{SourceLocation} \\
 		\DeclareMember{type}{TypeIndex} \\
-		\DeclareMember{impl}{DeclIndex} \\
+		\DeclareMember{impl}{ExprIndex} \\
 		\DeclareMember{argument}{ExprIndex} \\
 		\DeclareMember{assoc}{MonadicOperator} \\
 	}
@@ -537,7 +537,7 @@ Each entry in that partition is a structure with the following layout
 	\structure{
 		\DeclareMember{locus}{SourceLocation} \\
 		\DeclareMember{type}{TypeIndex} \\
-		\DeclareMember{impl}{DeclIndex} \\
+		\DeclareMember{impl}{ExprIndex} \\
 		\DeclareMember{arguments}{ExprIndex[2]} \\
 		\DeclareMember{assoc}{DyadicOperator} \\
 	}
@@ -571,7 +571,7 @@ Each entry in that partition is a structure with the following layout
 	\structure{
 		\DeclareMember{locus}{SourceLocation} \\
 		\DeclareMember{type}{TypeIndex} \\
-		\DeclareMember{impl}{DeclIndex} \\
+		\DeclareMember{impl}{ExprIndex} \\
 		\DeclareMember{arguments}{ExprIndex[3]} \\
 		\DeclareMember{assoc}{TriadicOperator} \\
 	}


### PR DESCRIPTION
Cameron DaCamara pointed to me that MSVC still has problems with making the semantic resolution of operator of type `DeclIndex` (because reasons).  This patch temporarily make them of type `ExprIndex` until the MSVC reasons are resolved (soon hopefully)