### PR TITLE
Saturated Arithmetic

### DIFF
--- a/ltx/exprs.tex
+++ b/ltx/exprs.tex
@@ -2184,6 +2184,7 @@ value of the \field{index} is to be interpreted as a value of type
 	\enumerator{MsvcBuiltinIsPointerInterconvertibleWithClass}
 	\enumerator{MsvcBuiltinIsCorrespondingMember}
 	\enumerator{MsvcIntrinsic}
+	\enumerator{MsvcSaturatedArithmetic}
 \end{Enumeration}
 
 \ifcSortSection{Unknown}{DyadicOperator} 
@@ -2484,6 +2485,11 @@ Source level ``\code{__builtin_is_corresponding_member}'' operator (\sortref{Msv
 Abstract machine operation corresponding to the call of an MSVC intrinsic operator of function.
 The first operand is an integer constant describing the intrinsic; the second operand is the argument list.
 See also \sortref{Call}{ExprSort}.
+
+\ifcSortSection{MsvcSaturatedArithmetic}{DyadicOpererator}
+An MSVC intrinsic for an abstract machine saturated arithemtic operation. 
+If the arithmetic computation described by the first operand overflows, 
+then the result is the saturated value indicated by the second operand.
 
 
 \subsection{Triadic operators}


### PR DESCRIPTION
Add missing description for saturated arithmetic mode on the MSVC toolset