### PR TITLE
Padding bytes in `SyntaxSort::FunctionDeclarator`

### DIFF
--- a/ltx/parse.tex
+++ b/ltx/parse.tex
@@ -695,6 +695,7 @@ Each entry in that partition is a structure with the following layout
 		\DeclareMember{ellipsis}{SourceLocation} \\
 		\DeclareMember{ref}{SourceLocation} \\
 		\DeclareMember{traits}{FunctionTypeTraits} \\
+		\DeclareMember{padding}{\arrayType{3}{u8}} \\
 	}
 	\label{fig:ifc:SyntaxSort:FunctionDeclarator}
 \end{figure}


### PR DESCRIPTION
The commit #60 was missing the padding bytes at the end of the structure.