### PR TITLE
Clarify `ExprtSort::QualifiedName`

### DIFF
--- a/ltx/exprs.tex
+++ b/ltx/exprs.tex
@@ -403,7 +403,7 @@ the qualified name partition.  Each entry of that partition has the following la
 	\label{fig:ifc-qualified-name-structure}
 \end{figure}
 %
-The \field{elements} field designates the sequence of unqualified names (\sortref{UnqualifiedId}{ExprSort})
+The \field{elements} field designates the sequence of unqualified names (e.g. \sortref{UnqualifiedId}{ExprSort}, \sortref{TemplateId}{ExprSort}, etc.)
  in the source level construct.  The \field{template\_keyword}, if not null, designates the presence of
  the \code{typename} keyword in the input source program to indicate to the parser that the qualified name actually names a type.
 


### PR DESCRIPTION
The components are NOT restricted to `ExprSort::UnqualifiedId`.

Fix #70