### PR TITLE
Add structure for default arguments

### DIFF
--- a/ltx/decls.tex
+++ b/ltx/decls.tex
@@ -24,7 +24,7 @@ declaration.  Like all abstract references, it is a 32-bit value
 	\enumerator{Template}
 	\enumerator{PartialSpecialization}
 	\enumerator{Specialization}
-	\enumerator{UnusedSort0}
+	\enumerator{DefaultArgument}
 	\enumerator{Concept}
 	\enumerator{Function}
 	\enumerator{Method}
@@ -745,10 +745,42 @@ with the following meaning
 \end{itemize}
 
 
-\subsection{\valueTag{DeclSort::UnusedSort0}} 
-\label{sec:ifc:DeclSort:UnusedSort0}
+\subsection{\valueTag{DeclSort::DefaultArgument}} 
+\label{sec:ifc:DeclSort:DefaultArgument}
 
-No structure associated with this sort.
+A \type{DeclIndex} value with tag \valueTag{DeclSort::DefaultArgument} represents an abstract reference
+to a default argument for a function parameter or a template parameter.  For all practical purposes (ODR),
+a default argument is modelled as a declaration.  
+The \field{index} of that abstract reference is an index into the default argument
+definition partition.  Each entry in that partition is a structure with the following layout
+%
+\begin{figure}[H]
+	\centering
+	\structure{
+		\DeclareMember{locus}{SourceLocation} \\
+		\DeclareMember{type}{TypeIndex} \\
+		\DeclareMember{home\_scope}{DeclIndex} \\
+		\DeclareMember{initializer}{ExprIndex} \\
+		\DeclareMember{specifiers}{BasicSpecifiers} \\
+		\DeclareMember{access}{Access} \\
+		\DeclareMember{properties}{ReachableProperties} \\
+	}
+\end{figure}
+%
+with the following meanings of the fields:
+\begin{itemize}
+	\item \field{locus} designates the source location of the default argument
+	\item \field{type} designates the type of the parameter corresponding to the default argument
+	\item \field{home\_scope} designates the scope where the default parameter is specified
+	\item \field{initializer} designates the expression specified in the default argument
+	\item \field{specifiers} denotes the basic specifiers of the default arguments
+	\item \field{access} denotes the control access of this default argument
+	\item \field{properties} denotes the reachable properties associated with the default argument
+\end{itemize}
+
+\note{The \field{home\_scope} field is currently null in the current IFC produced by the MSVC toolset.}
+
+\partition{decl.default-arg}
 
 \subsection{\valueTag{DeclSort::Concept}}
 \label{sec:ifc:DeclSort:Concept}

--- a/ltx/exprs.tex
+++ b/ltx/exprs.tex
@@ -1884,6 +1884,9 @@ value of the \field{index} is to be interpreted as a value of type
 	\enumerator{MsvcConfusion}
 	\enumerator{MsvcConfusedExpand}
 	\enumerator{MsvcConfusedDependentSizeof}
+	\enumerator{MsvcConfusedPopState}
+	\enumerator{MsvcConfusedDtorAction}
+	\enumerator{MsvcConfusedVtorDisplacement}
 \end{Enumeration}
 
 \ifcSortSection{Unknown}{MonadicOperator} 

--- a/ltx/stmts.tex
+++ b/ltx/stmts.tex
@@ -76,9 +76,6 @@ The fields have the following meanings:
 
 \partition{stmt.try}
 
-\diffNote{This partition sort value corresponds to \valueTag{StmtSort::Empty} in version 0.41 and prior. That statement sort was removed from this version.}
-
-
 \subsection{\valueTag{StmtSort::If}}
 \label{sec:ifc:StmtSort:If}
 
@@ -176,9 +173,6 @@ The fields have the following meanings:
 \end{itemize}
 
 \partition{stmt.labeled}
-
-\diffNote{This partition sort value corresponds to \valueTag{StmtSort::Case} in version 0.41 and prior. That statement sort was removed from this version.}
-
 
 \subsection{\valueTag{StmtSort::While}}
 \label{sec:ifc:StmtSort:While}
@@ -345,9 +339,6 @@ The fields have the following meanings:
 
 \partition{stmt.goto}
 
-\diffNote{This partition was \valueTag{StmtSort::Default} in version 0.41 and prior. That statement sort was removed from this version.}
-
-
 \subsection{\valueTag{StmtSort::Continue}}
 \label{sec:ifc:StmtSort:Continue}
 
@@ -451,9 +442,6 @@ The fields have the following meanings:
 \end{itemize}
 
 \partition{stmt.decl}
-
-\diffNote{This partition sort value corresponds to \valueTag{StmtSort::VariableDecl} in version 0.41 and prior. That statement sort was removed from this version.}
-
 
 \subsection{\valueTag{StmtSort::Expansion}}
 \label{sec:ifc:StmtSort:Expansion}


### PR DESCRIPTION
Add `DeclSort::DefaultArgument` to represent default arguments -- they are notionally declarations subject to the ODR, for all practical purposes.